### PR TITLE
Fixed define and declare confusion

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,1 +1,1 @@
-define module 'csv-string';
+declare module 'csv-string';


### PR DESCRIPTION
It should be `declare` module, not `define` module